### PR TITLE
Update plugin settings and validate plugin handshake

### DIFF
--- a/include/gradual_flow/gcode_path.h
+++ b/include/gradual_flow/gcode_path.h
@@ -159,8 +159,8 @@ struct GCodePath {
             const GCodePath gcode_path
             {
                 .original_gcode_path_data = original_gcode_path_data,
-                .speed = partition_speed,
                 .points = points,
+                .speed = partition_speed
             };
             return std::make_tuple(gcode_path, std::nullopt, remaining_partition_duration);
         }

--- a/include/plugin/broadcast.h
+++ b/include/plugin/broadcast.h
@@ -10,6 +10,7 @@
 #include <boost/asio/awaitable.hpp>
 #include <spdlog/spdlog.h>
 
+#include <coroutine>
 #include <functional>
 #include <memory>
 #include <unordered_map>
@@ -39,6 +40,7 @@ struct Broadcast
                 request,
                 writer,
                 boost::asio::use_awaitable);
+            spdlog::info("Received broadcast settings request");
             const google::protobuf::Empty response{};
             co_await agrpc::finish(writer, response, grpc::Status::OK, boost::asio::use_awaitable);
             settings->insert_or_assign(getUuid(server_context), Settings{ request });

--- a/include/plugin/handshake.h
+++ b/include/plugin/handshake.h
@@ -4,11 +4,15 @@
 #include "cura/plugins/slots/handshake/v0/handshake.grpc.pb.h"
 #include "cura/plugins/v0/slot_id.pb.h"
 #include "plugin/metadata.h"
+#include "plugin/settings.h"
 
+#include <agrpc/asio_grpc.hpp>
 #include <agrpc/rpc.hpp>
 #include <boost/asio/awaitable.hpp>
 #include <spdlog/spdlog.h>
 
+#include <coroutine>
+#include <memory>
 #include <string_view>
 
 namespace plugin
@@ -36,8 +40,22 @@ struct Handshake
                 request,
                 writer,
                 boost::asio::use_awaitable);
+
             spdlog::info("Received handshake request");
-            spdlog::info("Slot ID: {}, version_range: {}", static_cast<int>(request.slot_id()), request.version_range());
+            spdlog::info(
+                "Slot ID: {}, slot version range: {}, plugin name: {}, plugin version: {}",
+                static_cast<int>(request.slot_id()),
+                request.version_range(),
+                request.plugin_name(),
+                request.plugin_version());
+
+            const bool exists = Settings::validatePlugin(request, metadata);
+            if (! exists)
+            {
+                grpc::Status status = grpc::Status(grpc::StatusCode::INTERNAL, "Plugin could not be validated, handshake failed!");
+                co_await agrpc::finish_with_error(writer, status, boost::asio::use_awaitable);
+                continue;
+            }
 
             cura::plugins::slots::handshake::v0::CallResponse response;
             response.set_plugin_name(static_cast<std::string>(metadata->plugin_name));

--- a/include/plugin/modify.h
+++ b/include/plugin/modify.h
@@ -10,6 +10,7 @@
 #include <boost/asio/awaitable.hpp>
 #include <spdlog/spdlog.h>
 
+#include <coroutine>
 #include <filesystem>
 #include <fstream>
 #include <memory>

--- a/include/plugin/settings.h
+++ b/include/plugin/settings.h
@@ -2,76 +2,88 @@
 #define PLUGIN_SETTINGS_H
 
 #include "cura/plugins/slots/broadcast/v0/broadcast.grpc.pb.h"
-
-#include <semver.hpp>
+#include "cura/plugins/slots/handshake/v0/handshake.grpc.pb.h"
+#include "plugin/metadata.h"
 
 #include <algorithm>
 #include <cctype>
 #include <ctre.hpp>
 #include <locale>
 #include <optional>
+#include <semver.hpp>
 #include <string>
 #include <unordered_map>
 
 namespace plugin
 {
 
-    struct Settings
+struct Settings
+{
+    bool gradual_flow_enabled = { false };
+    double max_flow_acceleration = { 0.0 };
+    double layer_0_max_flow_acceleration = { 0.0 };
+    double gradual_flow_discretisation_step_size = { 0.0 };
+
+    explicit Settings(const cura::plugins::slots::broadcast::v0::BroadcastServiceSettingsRequest& msg)
     {
-        bool gradual_flow_enabled = { false };
-        double max_flow_acceleration = { 0.0 };
-        double layer_0_max_flow_acceleration = { 0.0 };
-        double gradual_flow_discretisation_step_size = { 0.0 };
+        const auto global_settings = msg.global_settings().settings();
 
-        explicit Settings(const cura::plugins::slots::broadcast::v0::BroadcastServiceSettingsRequest& msg)
+        gradual_flow_enabled = [global_settings]()
         {
-            const auto global_settings = msg.global_settings().settings();
-
-            gradual_flow_enabled = [global_settings](){
-                const auto gradual_flow_enabled_str = global_settings.at(settingKey("gradual_flow_enabled", "gradualflowplugin", "0.1.0"));
-                if (gradual_flow_enabled_str == "true" || gradual_flow_enabled_str == "True")
-                {
-                    return true;
-                }
-                if (gradual_flow_enabled_str == "false" || gradual_flow_enabled_str == "False")
-                {
-                    return false;
-                }
-                throw std::runtime_error("gradual_flow_enabled must be either True or False");
-            }();
-
-            max_flow_acceleration = std::atof(global_settings.at(settingKey("max_flow_acceleration", "gradualflowplugin", "0.1.0")).c_str()) * 1e9;
-            layer_0_max_flow_acceleration = std::atof(global_settings.at(settingKey("layer_0_max_flow_acceleration", "gradualflowplugin", "0.1.0")).c_str()) * 1e9;
-            gradual_flow_discretisation_step_size = std::atof(global_settings.at(settingKey("gradual_flow_discretisation_step_size", "gradualflowplugin", "0.1.0")).c_str());
-        }
-
-        static constexpr std::string_view getPattern(std::string_view pattern, std::string_view name)
-        {
-            if (auto [_, setting_namespace, plugin_name, plugin_version, pattern_name] = ctre::match<"^(.*?)::(.*?)@(.*?)::(.*?)$">(pattern);
-                    setting_namespace == "PLUGIN" && plugin_name == name)
+            const auto gradual_flow_enabled_str = global_settings.at(settingKey("gradual_flow_enabled", "gradualflowplugin", "0.1.0"));
+            if (gradual_flow_enabled_str == "true" || gradual_flow_enabled_str == "True")
             {
-                return pattern_name;
+                return true;
             }
-            return pattern;
-        }
+            if (gradual_flow_enabled_str == "false" || gradual_flow_enabled_str == "False")
+            {
+                return false;
+            }
+            throw std::runtime_error("gradual_flow_enabled must be either True or False");
+        }();
 
-        static std::string settingKey(std::string_view short_key, std::string_view name, std::string_view version)
+        // TODO: use retrieveSettings
+        max_flow_acceleration = std::atof(global_settings.at(settingKey("max_flow_acceleration", "gradualflowplugin", "0.1.0")).c_str()) * 1e9;
+        layer_0_max_flow_acceleration = std::atof(global_settings.at(settingKey("layer_0_max_flow_acceleration", "gradualflowplugin", "0.1.0")).c_str()) * 1e9;
+        gradual_flow_discretisation_step_size = std::atof(global_settings.at(settingKey("gradual_flow_discretisation_step_size", "gradualflowplugin", "0.1.0")).c_str());
+    }
+
+    static std::optional<std::string> retrieveSettings(std::string settings_key, const auto& request, const auto& metadata)
+    {
+        auto settings_key_ = settingKey(settings_key, metadata->plugin_name, metadata->plugin_version);
+        if (request.settings().settings().contains(settings_key_))
         {
-            std::string lower_name{ name };
-            auto semantic_version = semver::from_string(version);
-            std::transform(
-                    lower_name.begin(),
-                    lower_name.end(),
-                    lower_name.begin(),
-                    [](const auto& c)
-                    {
-                        return std::tolower(c);
-                    });
-            return fmt::format("_plugin__{}__{}_{}_{}__{}", lower_name, semantic_version.major, semantic_version.minor, semantic_version.patch, short_key);
+            return request.settings().settings().at(settings_key_);
         }
-    };
 
-    using settings_t = std::unordered_map<std::string, Settings>;
+        return std::nullopt;
+    }
+
+    static bool validatePlugin(const cura::plugins::slots::handshake::v0::CallRequest& request, const std::shared_ptr<Metadata>& metadata)
+    {
+        if (request.plugin_name() == metadata->plugin_name && request.plugin_version() == metadata->plugin_version)
+        {
+            return true;
+        }
+        return false;
+    }
+    static std::string settingKey(std::string_view short_key, std::string_view name, std::string_view version)
+    {
+        std::string lower_name{ name };
+        auto semantic_version = semver::from_string(version);
+        std::transform(
+            lower_name.begin(),
+            lower_name.end(),
+            lower_name.begin(),
+            [](const auto& c)
+            {
+                return std::tolower(c);
+            });
+        return fmt::format("_plugin__{}__{}_{}_{}__{}", lower_name, semantic_version.major, semantic_version.minor, semantic_version.patch, short_key);
+    }
+};
+
+using settings_t = std::unordered_map<std::string, Settings>;
 
 } // namespace plugin
 


### PR DESCRIPTION
This update includes two significant changes: 

1) Added a new functionality to retrieve and validate settings of a specific plugin, which refines the settings struct and adds the ability to separate and handle specific settings for each plugin more effectively. 
2) Updated the handshake protocol to validate the existence and compatibility of a specific plugin. These functionality enhancements were implemented to increase the robustness and reliability of the plugin handling system in the application.
3) minor fix: struct fields should be initialized in order

Contributes to CURA-10466