### PR TITLE
[CURA-11035] Plugins specify a verion-range, slots just a version.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -170,7 +170,7 @@ class CuraEngineGradualFlowPluginConan(ConanFile):
         self.requires("clipper/6.4.2")
         self.requires("ctre/3.7.2")
         self.requires("neargye-semver/0.3.0")
-        self.requires("curaengine_grpc_definitions/(latest)@ultimaker/cura_11035")  # FIXME!: Put back to .../testing after merge!
+        self.requires("curaengine_grpc_definitions/(latest)@ultimaker/testing")
 
     def build_requirements(self):
         self.test_requires("standardprojectsettings/[>=0.1.0]@ultimaker/stable")

--- a/conanfile.py
+++ b/conanfile.py
@@ -170,7 +170,7 @@ class CuraEngineGradualFlowPluginConan(ConanFile):
         self.requires("clipper/6.4.2")
         self.requires("ctre/3.7.2")
         self.requires("neargye-semver/0.3.0")
-        self.requires("curaengine_grpc_definitions/(latest)@ultimaker/testing")
+        self.requires("curaengine_grpc_definitions/(latest)@ultimaker/cura_11035")  # FIXME!: Put back to .../testing after merge!
 
     def build_requirements(self):
         self.test_requires("standardprojectsettings/[>=0.1.0]@ultimaker/stable")

--- a/include/plugin/handshake.h
+++ b/include/plugin/handshake.h
@@ -50,7 +50,7 @@ struct Handshake
             spdlog::info(
                 "Slot ID: {}, slot version range: {}, plugin name: {}, plugin version: {}",
                 static_cast<int>(request.slot_id()),
-                request.version_range(),
+                request.version(),
                 request.plugin_name(),
                 request.plugin_version());
 
@@ -64,7 +64,7 @@ struct Handshake
 
             cura::plugins::slots::handshake::v0::CallResponse response;
             response.set_plugin_name(static_cast<std::string>(metadata->plugin_name));
-            response.set_slot_version(static_cast<std::string>(metadata->slot_version));
+            response.set_slot_version_range(static_cast<std::string>(metadata->slot_version_range));
             response.set_plugin_version(static_cast<std::string>(metadata->plugin_version));
             for (auto slot_id : broadcast_subscriptions)
             {

--- a/include/plugin/metadata.h
+++ b/include/plugin/metadata.h
@@ -13,7 +13,7 @@ namespace plugin
 
 struct Metadata
 {
-    std::string_view slot_version_range{ ">=0.1.0" };
+    std::string_view slot_version_range{ ">=0.1.0 <0.2.0" };
     std::string_view plugin_name{ "CuraEngineGradualFlow" };
     std::string_view plugin_version{ cmdline::VERSION };
 };

--- a/include/plugin/metadata.h
+++ b/include/plugin/metadata.h
@@ -13,7 +13,7 @@ namespace plugin
 
 struct Metadata
 {
-    std::string_view slot_version{ "0.1.0-alpha" };
+    std::string_view slot_version_range{ ">=0.1.0" };
     std::string_view plugin_name{ "CuraEngineGradualFlow" };
     std::string_view plugin_version{ cmdline::VERSION };
 };


### PR DESCRIPTION
Not the other way around as we have now. This also adheres closer to the way we handle front-end plugins. Ideally you'd maybe want both of them to be ranges, but that's for the future.