### PR TITLE
CURA-10831

### DIFF
--- a/.github/workflows/conan-package.yml
+++ b/.github/workflows/conan-package.yml
@@ -1,10 +1,4 @@
----
 name: conan-package
-
-# Exports the recipe, sources and binaries for Mac, Windows and Linux and upload these to the server such that these can
-# be used downstream.
-#
-# It should run on pushes against main or CURA-* branches, but it will only create the binaries for main and release branches
 
 on:
   workflow_dispatch:
@@ -39,31 +33,44 @@ on:
       - '[0-9]+.[0-9]+.[0-9]'
 
 jobs:
+  # FIXME: Use `main` instead of `CURA-10831` once merged
   conan-recipe-version:
-    uses: ultimaker/cura/.github/workflows/conan-recipe-version.yml@main
+    uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-version.yml@CURA-10831
     with:
       project_name: curaengine_plugin_gradual_flow
 
+  # FIXME: Use `main` instead of `CURA-10831` once merged
   conan-package-export:
     needs: [ conan-recipe-version ]
-    uses: ultimaker/cura/.github/workflows/conan-recipe-export.yml@main
+    uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-export.yml@CURA-10831
     with:
       recipe_id_full: ${{ needs.conan-recipe-version.outputs.recipe_id_full }}
       recipe_id_latest: ${{ needs.conan-recipe-version.outputs.recipe_id_latest }}
-      runs_on: 'ubuntu-22.04'
-      python_version: '3.11.x'
-      conan_logging_level: 'info'
     secrets: inherit
 
-  notify-export:
-    if: ${{ always() }}
-    needs: [ conan-package-export ]
-
-    uses: ultimaker/cura/.github/workflows/notify.yml@main
+  # FIXME: Use `main` instead of `CURA-10831` once merged
+  conan-package-create-macos:
+    needs: [ conan-recipe-version, conan-package-export ]
+    if: ${{ (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master' || needs.conan-recipe-version.outputs.is_release_branch == 'true')) }}
+    uses: ultimaker/cura-workflows/.github/workflows/conan-package-create-macos.yml@CURA-10831
     with:
-      success: ${{ contains(join(needs.*.result, ','), 'success') }}
-      success_title: "New Conan recipe exported in ${{ github.repository }}"
-      success_body: "Exported ${{ needs.conan-recipe-version.outputs.recipe_id_full }}"
-      failure_title: "Failed to export Conan Export in ${{ github.repository }}"
-      failure_body: "Failed to exported ${{ needs.conan-recipe-version.outputs.recipe_id_full }}"
+      recipe_id_full: ${{ needs.conan-recipe-version.outputs.recipe_id_full }}
+    secrets: inherit
+
+  # FIXME: Use `main` instead of `CURA-10831` once merged
+  conan-package-create-windows:
+    needs: [ conan-recipe-version, conan-package-export ]
+    if: ${{ (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master' || needs.conan-recipe-version.outputs.is_release_branch == 'true')) }}
+    uses: ultimaker/cura-workflows/.github/workflows/conan-package-create-windows.yml@CURA-10831
+    with:
+      recipe_id_full: ${{ needs.conan-recipe-version.outputs.recipe_id_full }}
+    secrets: inherit
+
+  # FIXME: Use `main` instead of `CURA-10831` once merged
+  conan-package-create-linux:
+    needs: [ conan-recipe-version, conan-package-export ]
+    if: ${{ (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master' || needs.conan-recipe-version.outputs.is_release_branch == 'true')) }}
+    uses: ultimaker/cura-workflows/.github/workflows/conan-package-create-linux.yml@CURA-10831
+    with:
+      recipe_id_full: ${{ needs.conan-recipe-version.outputs.recipe_id_full }}
     secrets: inherit

--- a/.github/workflows/conan-package.yml
+++ b/.github/workflows/conan-package.yml
@@ -33,44 +33,39 @@ on:
       - '[0-9]+.[0-9]+.[0-9]'
 
 jobs:
-  # FIXME: Use `main` instead of `CURA-10831` once merged
   conan-recipe-version:
-    uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-version.yml@CURA-10831
+    uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-version.yml@main
     with:
       project_name: curaengine_plugin_gradual_flow
 
-  # FIXME: Use `main` instead of `CURA-10831` once merged
   conan-package-export:
     needs: [ conan-recipe-version ]
-    uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-export.yml@CURA-10831
+    uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-export.yml@main
     with:
       recipe_id_full: ${{ needs.conan-recipe-version.outputs.recipe_id_full }}
       recipe_id_latest: ${{ needs.conan-recipe-version.outputs.recipe_id_latest }}
     secrets: inherit
 
-  # FIXME: Use `main` instead of `CURA-10831` once merged
   conan-package-create-macos:
     needs: [ conan-recipe-version, conan-package-export ]
     if: ${{ (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master' || needs.conan-recipe-version.outputs.is_release_branch == 'true')) }}
-    uses: ultimaker/cura-workflows/.github/workflows/conan-package-create-macos.yml@CURA-10831
+    uses: ultimaker/cura-workflows/.github/workflows/conan-package-create-macos.yml@main
     with:
       recipe_id_full: ${{ needs.conan-recipe-version.outputs.recipe_id_full }}
     secrets: inherit
 
-  # FIXME: Use `main` instead of `CURA-10831` once merged
   conan-package-create-windows:
     needs: [ conan-recipe-version, conan-package-export ]
     if: ${{ (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master' || needs.conan-recipe-version.outputs.is_release_branch == 'true')) }}
-    uses: ultimaker/cura-workflows/.github/workflows/conan-package-create-windows.yml@CURA-10831
+    uses: ultimaker/cura-workflows/.github/workflows/conan-package-create-windows.yml@main
     with:
       recipe_id_full: ${{ needs.conan-recipe-version.outputs.recipe_id_full }}
     secrets: inherit
 
-  # FIXME: Use `main` instead of `CURA-10831` once merged
   conan-package-create-linux:
     needs: [ conan-recipe-version, conan-package-export ]
     if: ${{ (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master' || needs.conan-recipe-version.outputs.is_release_branch == 'true')) }}
-    uses: ultimaker/cura-workflows/.github/workflows/conan-package-create-linux.yml@CURA-10831
+    uses: ultimaker/cura-workflows/.github/workflows/conan-package-create-linux.yml@main
     with:
       recipe_id_full: ${{ needs.conan-recipe-version.outputs.recipe_id_full }}
     secrets: inherit

--- a/.github/workflows/unit-test-post.yml
+++ b/.github/workflows/unit-test-post.yml
@@ -6,9 +6,8 @@ on:
     types: [ completed ]
 
 jobs:
-  # FIXME: Use `main` instead of `CURA-10831` once merged
   publish-test-results:
-    uses: ultimaker/cura-workflows/.github/workflows/unit-test-post.yml@CURA-10831
+    uses: ultimaker/cura-workflows/.github/workflows/unit-test-post.yml@main
     with:
       event: ${{ github.event.workflow_run.event }}
       conclusion: ${{ github.event.workflow_run.conclusion }}

--- a/.github/workflows/unit-test-post.yml
+++ b/.github/workflows/unit-test-post.yml
@@ -1,0 +1,14 @@
+name: unit-test-post
+
+on:
+  workflow_run:
+    workflows: [ unit-test ]
+    types: [ completed ]
+
+jobs:
+  # FIXME: Use `main` instead of `CURA-10831` once merged
+  publish-test-results:
+    uses: ultimaker/cura-workflows/.github/workflows/unit-test-post.yml@CURA-10831
+    with:
+      event: ${{ github.event.workflow_run.event }}
+      conclusion: ${{ github.event.workflow_run.conclusion }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -34,14 +34,13 @@ env:
   CONAN_PASSWORD: ${{ secrets.CONAN_PASS }}
 
 jobs:
-  # FIXME: Change to `main` instead of `CURA-10831` once merged
   conan-recipe-version:
-    uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-version.yml@CURA-10831
+    uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-version.yml@main
     with:
       project_name: curaengine_plugin_gradual_flow
 
   testing:
-    uses: ultimaker/cura-workflows/.github/workflows/unit-test.yml@CURA-10831
+    uses: ultimaker/cura-workflows/.github/workflows/unit-test.yml@main
     needs: [ conan-recipe-version ]
     with:
       recipe_id_full: ${{ needs.conan-recipe-version.outputs.recipe_id_full }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,4 +1,3 @@
----
 name: unit-test
 on:
   push:
@@ -6,138 +5,47 @@ on:
       - 'include/**'
       - 'src/**'
       - 'tests/**'
-      - 'test_package/**'
-      - 'conanfile.py'
       - 'CMakeLists.txt'
       - '.github/workflows/unit-test.yml'
-      - '.github/workflows/requirements-conan-package.txt'
+      - '.github/workflows/unit-test-post.yml'
     branches:
       - main
       - '[0-9]+.[0-9]+'
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+
   pull_request:
     types: [ opened, reopened, synchronize ]
     paths:
       - 'include/**'
       - 'src/**'
       - 'tests/**'
-      - 'test_package/**'
-      - 'conanfile.py'
       - 'CMakeLists.txt'
       - '.github/workflows/unit-test.yml'
-      - '.github/workflows/requirements-conan-package.txt'
+      - '.github/workflows/unit-test-post.yml'
     branches:
       - main
       - 'CURA-*'
       - '[0-9]+.[0-9]+'
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: read
 
 env:
-  CONAN_LOGIN_USERNAME_CURA: ${{ secrets.CONAN_USER }}
-  CONAN_PASSWORD_CURA: ${{ secrets.CONAN_PASS }}
-  CONAN_LOGIN_USERNAME_CURA_CE: ${{ secrets.CONAN_USER }}
-  CONAN_PASSWORD_CURA_CE: ${{ secrets.CONAN_PASS }}
-  CONAN_LOG_RUN_TO_OUTPUT: 1
-  CONAN_LOGGING_LEVEL: info
-  CONAN_NON_INTERACTIVE: 1
+  CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_USER }}
+  CONAN_PASSWORD: ${{ secrets.CONAN_PASS }}
 
 jobs:
+  # FIXME: Change to `main` instead of `CURA-10831` once merged
   conan-recipe-version:
-    uses: ultimaker/cura/.github/workflows/conan-recipe-version.yml@main
+    uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-version.yml@CURA-10831
     with:
       project_name: curaengine_plugin_gradual_flow
 
   testing:
-    runs-on: ubuntu-22.04
+    uses: ultimaker/cura-workflows/.github/workflows/unit-test.yml@CURA-10831
     needs: [ conan-recipe-version ]
-
-    steps:
-      - name: Checkout CuraEngine
-        uses: actions/checkout@v3
-
-      - name: Setup Python and pip
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11.x'
-          architecture: 'x64'
-          cache: 'pip'
-          cache-dependency-path: .github/workflows/requirements-conan-package.txt
-
-      - name: Install Python requirements and Create default Conan profile
-        run: |
-          pip install -r .github/workflows/requirements-conan-package.txt
-
-      # NOTE: Due to what are probably github issues, we have to remove the cache and reconfigure before the rest.
-      #       This is maybe because grub caches the disk it uses last time, which is recreated each time.
-      - name: Install Linux system requirements
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          sudo rm /var/cache/debconf/config.dat
-          sudo dpkg --configure -a
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-          sudo apt update
-          sudo apt upgrade
-          sudo apt install build-essential checkinstall libegl-dev zlib1g-dev libssl-dev ninja-build autoconf libx11-dev libx11-xcb-dev libfontenc-dev libice-dev libsm-dev libxau-dev libxaw7-dev libxcomposite-dev libxcursor-dev libxdamage-dev libxdmcp-dev libxext-dev libxfixes-dev libxi-dev libxinerama-dev libxkbfile-dev libxmu-dev libxmuu-dev libxpm-dev libxrandr-dev libxrender-dev libxres-dev libxss-dev libxt-dev libxtst-dev libxv-dev libxvmc-dev libxxf86vm-dev xtrans-dev libxcb-render0-dev libxcb-render-util0-dev libxcb-xkb-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-shape0-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-xinerama0-dev xkb-data libxcb-dri3-dev uuid-dev libxcb-util-dev libxkbcommon-x11-dev pkg-config -y
-
-      - name: Install GCC-13 on ubuntu
-        run: |
-          sudo apt install g++-13 gcc-13 -y
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 13
-
-      - name: Create the default Conan profile
-        run: conan profile new default --detect
-
-      - name: Get Conan configuration
-        run: |
-          conan config install https://github.com/Ultimaker/conan-config.git
-          conan config install https://github.com/Ultimaker/conan-config.git -a "-b runner/${{ runner.os }}/${{ runner.arch }}"
-
-      - name: Use Conan download cache (Bash)
-        if: ${{ runner.os != 'Windows' }}
-        run: conan config set storage.download_cache="$HOME/.conan/conan_download_cache"
-
-      - name: Cache Conan local repository packages (Bash)
-        uses: actions/cache@v3
-        if: ${{ runner.os != 'Windows' }}
-        with:
-          path: |
-            $HOME/.conan/data
-            $HOME/.conan/conan_download_cache
-          key: conan-${{ runner.os }}-${{ runner.arch }}
-
-      - name: Install dependencies
-        run: conan install . ${{ needs.conan-recipe-version.outputs.recipe_id_full }} -s build_type=Release --build=missing --update -g GitHubActionsRunEnv -g GitHubActionsBuildEnv
-
-      - name: Upload the Dependency package(s)
-        run: conan upload "*" -r cura --all -c
-
-      - name: Set Environment variables from Conan install (bash)
-        if: ${{ runner.os != 'Windows' }}
-        run: |
-          . ./activate_github_actions_runenv.sh
-          . ./activate_github_actions_buildenv.sh
-        working-directory: build/Release/generators
-
-      - name: Build Gradual flow plugin and tests
-        run: |
-          cmake --preset release
-          cmake --build --preset release
-
-      - name: Run Unit Test Gradual flow plugin
-        id: run-test
-        run: ctest --output-junit plugin_test.xml
-        working-directory: build/Release
-
-      - name: Publish Unit Test Results
-        id: test-results
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        if: ${{ always() }}
-        with:
-          files: |
-            **/*.xml
-
-      - name: Conclusion
-        run: echo "Conclusion is ${{ fromJSON( steps.test-results.outputs.json ).conclusion }}"
+    with:
+      recipe_id_full: ${{ needs.conan-recipe-version.outputs.recipe_id_full }}
+      conan_extra_args: '-c tools.build:skip_test=False'
+      unit_test_cmd: 'ctest --output-junit plugin_test.xml'
+      unit_test_dir: 'build/Release'
+      build: true

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,0 +1,3 @@
+version: "0.1.0-beta.2"
+requirements:
+    - "curaengine_grpc_definitions/(latest)@ultimaker/cura_10831"

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import copy
+from conan.tools.files import copy, update_conandata
 from conan.tools.microsoft import check_min_vs, is_msvc_static_runtime, is_msvc
 from conan.tools.scm import Version
 
@@ -35,7 +35,7 @@ class CuraEngineGradualFlowPluginConan(ConanFile):
 
     def set_version(self):
         if not self.version:
-            self.version = "0.1.0"
+            self.version = self.conan_data["version"]
 
     @property
     def _min_cppstd(self):
@@ -136,6 +136,9 @@ class CuraEngineGradualFlowPluginConan(ConanFile):
                                     website=self.url,
                                     website_author=self.homepage))
 
+    def export(self):
+        update_conandata(self, {"version": self.version})
+
     def export_sources(self):
         copy(self, "CMakeLists.txt", self.recipe_folder, self.export_sources_folder)
         copy(self, "*.jinja", os.path.join(self.recipe_folder, "templates"), os.path.join(self.export_sources_folder, "templates"))
@@ -160,6 +163,8 @@ class CuraEngineGradualFlowPluginConan(ConanFile):
                                     os.path.join("res", "bundled_packages").replace("\\", "/")]
 
     def requirements(self):
+        for req in self.conan_data["requirements"]:
+            self.requires(req)
         self.requires("protobuf/3.21.9")
         self.requires("boost/1.82.0")
         self.requires("asio-grpc/2.6.0")
@@ -170,7 +175,6 @@ class CuraEngineGradualFlowPluginConan(ConanFile):
         self.requires("clipper/6.4.2")
         self.requires("ctre/3.7.2")
         self.requires("neargye-semver/0.3.0")
-        self.requires("curaengine_grpc_definitions/0.1.0")
 
     def build_requirements(self):
         self.test_requires("standardprojectsettings/[>=0.1.0]@ultimaker/stable")


### PR DESCRIPTION
# Description
Ported a lot of workflow to use the reusable workflows in the new [Cura-workflows](https://github.com/Ultimaker/Cura-workflows) repository. See PR: https://github.com/Ultimaker/cura-workflows/pull/1 

The biggest impact on this repository is that the version of the conan package is now determined by the `version` key in `conandata.yml` and no longer determined based on the git tag. During a push the Conan user, channel is determined based Github runner context, see the `conan-recipe-versions.yml` in the Cura-workflows and the semver build metadata is added from the sha of the reference name (git hash).

Furthermore the CuraEngine Gradual Flow dependencies maintained by UltiMaker (e.q.: curaengine_grpc_definitions) are no longer specified in the `conanfile.py` but are also present in the `conandata.yml` which allows us to automate the user and channel on main and release branches in the future. Since it is a yaml file which can be read in and easily changed by an automated workflow. For instance change the Conan channel to `stable` when we create the release branch. Or pin to specific conan package release version (e.q.: `curaengine_grpc_definitions/0.2.0@_/_`) when we create an actual release.

> When you now create a release branch now you would need to do this manually.

> **NOTE:** Since technically these changes would result in version: `0.1.1-beta.0+git_sha`, which would cause all kinds of issues in Cura with the settings key `_plugin_gradual_flow_0_1_1__` hence by putting the version in the `conandata.yml` to `0.1.0-beta.2` I could cheat a bit without writing the upgrade scripts etc during the ticket.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Locally
- [X] Remote

**Test Configuration**:
* Operating System: Linux, Windows, Mac

# Checklist:
<!-- Check if relevant -->

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change
