### PR TITLE
Typo fix

### DIFF
--- a/CuraEngineGradualFlow/gradual_flow_settings.def.json
+++ b/CuraEngineGradualFlow/gradual_flow_settings.def.json
@@ -21,7 +21,7 @@
         "minimum_value": 0.01,
         "settable_per_mesh": false,
         "settable_per_extruder": true,
-        "comment": "when enabled, each second the flow will at max be increased/decreased by this value"
+        "comments": "when enabled, each second the flow will at max be increased/decreased by this value"
       },
       "layer_0_max_flow_acceleration": {
         "enabled": "gradual_flow_enabled",


### PR DESCRIPTION
comment -> comments
resolves warnings for unrecognized property comment

Based on:
SettingsDefinitions.py -> __property_definitions-> "comments": {"type": DefinitionPropertyType.String,...

CURA-12036